### PR TITLE
Fix shebang for Ubuntu 18.04

### DIFF
--- a/extra/events2trace.py
+++ b/extra/events2trace.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 """
 Assembles a trace file for the chromium tracing tool using multiple log files and prints the result.
 


### PR DESCRIPTION
`/bin/env` does not exist on Ubuntu 18.04. I think the (most) canonical way of defining the shebang is `/usr/bin/env`.