### PR TITLE
Fix name in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 ### Basics
 Import the main header
 ```
-#include "EventTimings/Events.hpp"
+#include "EventTimings/Event.hpp"
 #include "EventTimings/EventUtils.hpp"
 ```
 All classes and functions are in the namespace `EventTimings::`.


### PR DESCRIPTION
Just run into this problem after installing EventTimings via `cmake . && sudo make install`.