### PR TITLE
inconsistency in calling the instance() method

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,11 +13,11 @@ All classes and functions are in the namespace `EventTimings::`.
 ### Initialization
 Initalize the timing framework at program start:
 ```
-EventRegistry.instance().initialize("applicationName");
+EventRegistry::instance().initialize("applicationName");
 ```
 finalize the same way
 ```
-EventRegistry.instance().finalize();
+EventRegistry::instance().finalize();
 ```
 `"applicationName"` is optional and is used for naming the output files.
 
@@ -53,7 +53,7 @@ The barrier can be used to synchronize measurements across the MPI communicator.
 
 If you don't want an `Event` to be stopped when it goes out of scope, you can retrieve a so called stored `Event`
 ```
-EventRegistry.instance().getStoredEvent("A stored Event");
+EventRegistry::instance().getStoredEvent("A stored Event");
 ```
 it needs to be started and stopped explicitly.
 


### PR DESCRIPTION
In the README.md file sometimes a dot is used and sometimes the scope resolution operator ::  
while using EventTimings, only the scope resolution operator worked for me. If the dot is considered correct, I suggest using it everywhere for consistency.